### PR TITLE
Update to DDF 2.26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,19 +35,20 @@
     </licenses>
 
     <properties>
-        <ddf.version>2.20.0</ddf.version>
+        <ddf.version>2.26.1</ddf.version>
         <ddf.support.version>2.3.16</ddf.support.version>
-        <camel.version>2.24.2</camel.version>
+        <camel.version>3.4.0</camel.version>
         <codice-test.version>0.9</codice-test.version>
-        <guava.version>20.0</guava.version>
+        <guava.version>29.0-jre</guava.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
+        <javax.ws.rs.version>2.1</javax.ws.rs.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <mockito.version>1.10.19</mockito.version>
         <junit.version>4.12</junit.version>
         <jacoco.version>0.8.2</jacoco.version>
-        <org.slf4j.version>1.7.25</org.slf4j.version>
+        <org.slf4j.version>1.7.29</org.slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -38,18 +38,8 @@
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-            <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-commons</artifactId>
-            <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.security</groupId>
-            <artifactId>ddf-security-common</artifactId>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
@@ -63,13 +53,13 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.mime.core</groupId>
-            <artifactId>mime-core-impl</artifactId>
-            <version>${ddf.version}</version>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>${javax.ws.rs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-aws</artifactId>
+            <artifactId>camel-aws-s3</artifactId>
             <version>${camel.version}</version>
         </dependency>
     </dependencies>
@@ -87,9 +77,9 @@
                             ${project.artifactId};blueprint.graceperiod:=true;blueprint.timeout:=604800000
                         </Bundle-SymbolicName>
                         <Import-Package>
-                            com.google.common.base;version="[20.0.0, 26.0.0)",
-                            com.google.common.collect;version="[20.0.0, 26.0.0)",
-                            com.google.common.io;version="[20.0.0, 26.0.0)",
+                            com.google.common.base;version="[20.0.0, 30.0.0)",
+                            com.google.common.collect;version="[20.0.0, 30.0.0)",
+                            com.google.common.io;version="[20.0.0, 30.0.0)",
                             org.opengis.annotation;version="[19.1, 21)",
                             org.opengis.filter;version="[19.1, 21)",
                             org.opengis.filter.expression;version="[19.1, 21)",


### PR DESCRIPTION
### Description
The s3 storage provider no longer installs on DDF 2.26.1 because DDF uses a newer Guava version. This PR fixes that. 

I went ahead and bumped all versions to match the version DDF is using. But I kept the version ranges and didn't have to make any code changes, ~so this should still run on older versions~ It won't work as-is because it will try to import the newer version of the DDF packages

